### PR TITLE
Use sprig

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -4,3 +4,5 @@ import:
 - package: github.com/docker/go-units
 - package: github.com/olekukonko/tablewriter
 - package: github.com/fatih/color
+- package: github.com/Masterminds/sprig
+  version: ^2.15.0

--- a/pkg/template/functions.go
+++ b/pkg/template/functions.go
@@ -1,100 +1,19 @@
 package template
 
 import (
-	"fmt"
-	"os"
-	"os/user"
-	"reflect"
-	"strconv"
-	"strings"
-	"text/template"
-	"time"
+	"github.com/Masterminds/sprig"
 )
 
+// Use the sprig library's template functions.  While this is a break from previous versions of
+// boilr, it has several advantages.
+// - sprig is used by several large projects (such as helm) and therefore its functions are familiar
+// - sprig's functions have the correct signatures for pipelining
+// - sprig has, at the time of writing, over 100 functions
+// The before-fork tag can be used to view the functions before this change. If we find they are
+// needed, we should attempt PRs to sprig and only add them back here if they are not accepted.
+
 var (
-	// FuncMap contains the functions exposed to templating engine.
-	FuncMap = template.FuncMap{
-		// TODO confirmation prompt
-		// TODO value prompt
-		// TODO encoding utilities (e.g. toBinary)
-		// TODO GET, POST utilities
-		// TODO Hostname(Also accesible through $HOSTNAME), interface IP addr, etc.
-		// TODO add validate for custom regex and expose validate package
-		"env":      os.Getenv,
-		"time":     CurrentTimeInFmt,
-		"hostname": func() string { return os.Getenv("HOSTNAME") },
-		"username": func() string {
-			t, err := user.Current()
-			if err != nil {
-				return "Unknown"
-			}
-
-			return t.Name
-		},
-		"toBinary": func(s string) string {
-			n, err := strconv.Atoi(s)
-			if err != nil {
-				return s
-			}
-
-			return fmt.Sprintf("%b", n)
-		},
-
-		"formatFilesize": func(value interface{}) string {
-			var size float64
-
-			v := reflect.ValueOf(value)
-			switch v.Kind() {
-			case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-				size = float64(v.Int())
-			case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-				size = float64(v.Uint())
-			case reflect.Float32, reflect.Float64:
-				size = v.Float()
-			default:
-				return ""
-			}
-
-			var KB float64 = 1 << 10
-			var MB float64 = 1 << 20
-			var GB float64 = 1 << 30
-			var TB float64 = 1 << 40
-			var PB float64 = 1 << 50
-
-			filesizeFormat := func(filesize float64, suffix string) string {
-				return strings.Replace(fmt.Sprintf("%.1f %s", filesize, suffix), ".0", "", -1)
-			}
-
-			var result string
-			if size < KB {
-				result = filesizeFormat(size, "bytes")
-			} else if size < MB {
-				result = filesizeFormat(size/KB, "KB")
-			} else if size < GB {
-				result = filesizeFormat(size/MB, "MB")
-			} else if size < TB {
-				result = filesizeFormat(size/GB, "GB")
-			} else if size < PB {
-				result = filesizeFormat(size/TB, "TB")
-			} else {
-				result = filesizeFormat(size/PB, "PB")
-			}
-
-			return result
-		},
-
-		// String utilities
-		"toLower": strings.ToLower,
-		"toUpper": strings.ToUpper,
-		"toTitle": strings.ToTitle,
-		"title":   strings.Title,
-
-		"trimSpace":  strings.TrimSpace,
-		"trimPrefix": strings.TrimPrefix,
-		"trimSuffix": strings.TrimSuffix,
-
-		"repeat": strings.Repeat,
-	}
+	FuncMap = sprig.TxtFuncMap()
 
 	// Options contain the default options for the template execution.
 	Options = []string{
@@ -102,11 +21,3 @@ var (
 		"missingkey=invalid",
 	}
 )
-
-// CurrentTimeInFmt returns the current time in the given format.
-// See time.Time.Format for more details on the format string.
-func CurrentTimeInFmt(fmt string) string {
-	t := time.Now()
-
-	return t.Format(fmt)
-}


### PR DESCRIPTION
Use [Sprig](https://github.com/Masterminds/sprig) rather than the template functions that had been previously coded into boilr.
Reasons...
- Sprig is fairly commonly used (helm uses it for example)
- Sprig has a large and growing library of pipeline functions
- The functions are coded properly for pipelining while boilr's were not

This is a breaking change because...
- Sprig has overlapping functions which do not have the same signature
- Boilr had several functions which were not included in Sprig but we did not currently use.  As we encounter use cases for them we will determine whether we should send PRs to Sprig or add them back to boilr.