### PR TITLE
Add the ability to save local defaults (and simplify binding logic)

### DIFF
--- a/pkg/boilr/configuration.go
+++ b/pkg/boilr/configuration.go
@@ -30,6 +30,9 @@ const (
 	// ContextFileName is the name of the file that contains the context values for the template
 	ContextFileName = "project.json"
 
+	// LocalDefaultsFileName is the name of a file in the current directory which will override the context values for the template
+	LocalDefaultsFileName = ".boilr-defaults.json"
+
 	// TemplateDirName is the name of the directory that contains the template files in a boilr template
 	TemplateDirName = "template"
 

--- a/pkg/cmd/use.go
+++ b/pkg/cmd/use.go
@@ -86,6 +86,12 @@ var Use = &cli.Command{
 			}
 			defer os.RemoveAll(tmpDir)
 
+			if err := osutil.Copy(filepath.Join(targetDir, boilr.LocalDefaultsFileName), filepath.Join(tmpDir, boilr.LocalDefaultsFileName)); err != nil {
+				if !os.IsNotExist(err) {
+					return err
+				}
+			}
+
 			if err := tmpl.Execute(tmpDir); err != nil {
 				return err
 			}

--- a/pkg/util/osutil/fs.go
+++ b/pkg/util/osutil/fs.go
@@ -86,28 +86,37 @@ func CopyRecursively(srcPath, dstPath string) error {
 				}
 			}
 		} else {
-			fi, err := os.Lstat(fname)
-			if err != nil {
-				return err
-			}
-
-			srcf, err := os.Open(fname)
-			if err != nil {
-				return err
-			}
-			defer srcf.Close()
-
-			dstf, err := os.OpenFile(mirrorPath, os.O_CREATE|os.O_WRONLY, fi.Mode())
-			if err != nil {
-				return err
-			}
-			defer dstf.Close()
-
-			if _, err := io.Copy(dstf, srcf); err != nil {
+			if err := Copy(fname, mirrorPath); err != nil {
 				return err
 			}
 		}
 
 		return nil
 	})
+}
+
+// Copy copies a single file from srcPath to dstPath
+func Copy(srcPath, dstPath string) error {
+	fi, err := os.Lstat(srcPath)
+	if err != nil {
+		return err
+	}
+
+	srcf, err := os.Open(srcPath)
+	if err != nil {
+		return err
+	}
+	defer srcf.Close()
+
+	dstf, err := os.OpenFile(dstPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, fi.Mode())
+	if err != nil {
+		return err
+	}
+	defer dstf.Close()
+
+	if _, err := io.Copy(dstf, srcf); err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
While this PR primarily adds the ability to save the values entered during the previous run of boilr as a local defaults file and reuse them for subsequent runs, it also corrects some closure-related issues in the option binding code.